### PR TITLE
Fix Glibc and Expect, add CrashplanPRO support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM alpine:latest
 #########################################
 # Set correct environment variables
 ENV CRASHPLAN_VERSION=4.7.0 \
-    GLIBC_VERSION=2.23-r1   \
+    CRASHPLAN_SERVICE=HOME  \
+    GLIBC_VERSION=2.23-r2   \
     LC_ALL=en_US.UTF-8      \
     LANG=en_US.UTF-8        \
     LANGUAGE=en_US.UTF-8

--- a/files/crashplan.exp
+++ b/files/crashplan.exp
@@ -1,5 +1,7 @@
 #!/usr/bin/env expect
 
+set timeout 120
+
 spawn "./install.sh"
 
 expect "Press enter to continue with installation."


### PR DESCRIPTION
Alpine Linux glibc changed maintainers, so I changed all references to the new repo. Also, I was having trouble with the expect script timing out when the crashplan installer downloads a JRE. Setting a timeout fixes that.

I introduced an environment variable in the Dockerfile that allows installing CrashplanPRO for small business users. It could possibly be built as it's own "official" image but for now, this satisfied my immediate need.
