### PR TITLE
Fix build failure on CentOS 7.

### DIFF
--- a/files/install.sh
+++ b/files/install.sh
@@ -60,6 +60,6 @@ rm -rf /usr/local/crashplan/jre/lib/plugin.jar \
    /usr/local/crashplan/jre/lib/amd64/libjavafx*.so \
    /usr/local/crashplan/jre/lib/amd64/libjfx*.so
 
-rm -rf /boot /home /lost+found /media /mnt /run /srv
+rm -rf /boot /home /lost+found /media /mnt /srv
 rm -rf /usr/local/crashplan/log
 rm -rf /var/cache/apk/*


### PR DESCRIPTION
I tried to build this Docker image on a CentOS 7 system with the `docker-latest` package (version 1.12.1) and it fails at the end of the build with this error:

```
rm: cannot remove '/run/secrets': Resource busy
The command '/bin/sh -c chmod +x /tmp/installation/install.sh && sync && /tmp/installation/install.sh && rm -rf /tmp/installation' returned a non-zero code: 1
```

It seems that Docker on Red Hat systems mounts something at `/run/secrets`.

The fix is simple and non-intrusive - simply don't try to remove `/run`. It doesn't seem to contain any files anyway, so no worries about image size.
